### PR TITLE
Use the same RUNNER_ETC_DIR for ddb and admin

### DIFF
--- a/rel/files/ddb-admin
+++ b/rel/files/ddb-admin
@@ -8,7 +8,7 @@ RUNNER_SCRIPT_DIR=$(cd ${0%/*} && pwd)
 RUNNER_SCRIPT=${0##*/}
 
 RUNNER_BASE_DIR=${RUNNER_SCRIPT_DIR%/*}
-RUNNER_ETC_DIR=$RUNNER_BASE_DIR/etc
+RUNNER_ETC_DIR={{etc_path}}
 RUNNER_LOG_DIR={{log_path}}
 RUNNER_USER={{run_user}}
 


### PR DESCRIPTION
Otherwise, ddb-admin installed from the .deb looks into a different location than ddb and operating on a cluster of nodes is not possible.
