### PR TITLE
Additional internal dalmatiner metrics

### DIFF
--- a/apps/dalmatiner_db/src/bkt_dict.erl
+++ b/apps/dalmatiner_db/src/bkt_dict.erl
@@ -17,7 +17,7 @@ new(Bkt, N, W) ->
 
 add(Metric, Time, Points, BD = #bkt_dict{ppf = PPF}) ->
     Count = mmath_bin:length(Points),
-    dalmatiner_metrics:inc(Count),
+    dalmatiner_metrics:inc(Count, mps),
     Splits = mstore:make_splits(Time, Count, PPF),
     insert_metric(Metric, Splits, Points, BD).
 

--- a/apps/dalmatiner_db/src/bkt_dict.erl
+++ b/apps/dalmatiner_db/src/bkt_dict.erl
@@ -17,7 +17,7 @@ new(Bkt, N, W) ->
 
 add(Metric, Time, Points, BD = #bkt_dict{ppf = PPF}) ->
     Count = mmath_bin:length(Points),
-    dalmatiner_metrics:inc(Count, mps),
+    dalmatiner_metrics:inc(Count),
     Splits = mstore:make_splits(Time, Count, PPF),
     insert_metric(Metric, Splits, Points, BD).
 

--- a/apps/dalmatiner_db/src/bkt_dict.erl
+++ b/apps/dalmatiner_db/src/bkt_dict.erl
@@ -17,7 +17,7 @@ new(Bkt, N, W) ->
 
 add(Metric, Time, Points, BD = #bkt_dict{ppf = PPF}) ->
     Count = mmath_bin:length(Points),
-    dalmatiner_metrics:inc(Count),
+    dalmatiner_metrics:inc_mps(Count),
     Splits = mstore:make_splits(Time, Count, PPF),
     insert_metric(Metric, Splits, Points, BD).
 

--- a/apps/dalmatiner_db/src/dalmatiner_db_app.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_db_app.erl
@@ -30,6 +30,7 @@ start(_StartType, _StartArgs) ->
     folsom_metrics:new_histogram(get, slide, 60),
     folsom_metrics:new_histogram(list_buckets, slide, 60),
     folsom_metrics:new_histogram(list_metrics, slide, 60),
+    folsom_metrics:new_histogram(io_queue_length, slide, 60),
 
     dalmatiner_db_sup:start_link().
 

--- a/apps/dalmatiner_db/src/dalmatiner_db_app.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_db_app.erl
@@ -31,6 +31,7 @@ start(_StartType, _StartArgs) ->
     folsom_metrics:new_histogram(list_buckets, slide, 60),
     folsom_metrics:new_histogram(list_metrics, slide, 60),
     folsom_metrics:new_histogram(io_queue_length, slide, 60),
+    folsom_metrics:new_meter(read_repairs),
 
     dalmatiner_db_sup:start_link().
 

--- a/apps/dalmatiner_db/src/dalmatiner_metrics.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_metrics.erl
@@ -14,7 +14,7 @@
 
 
 %% API
--export([start_link/0, inc/1, inc/0]).
+-export([start_link/0, inc_mps/1, inc_repairs/0, inc_repairs/1]).
 
 -ignore_xref([start_link/0, inc/0]).
 
@@ -26,6 +26,7 @@
 -define(INTERVAL, 1000).
 -define(BUCKET, <<"dalmatinerdb">>).
 -define(COUNTERS_MPS, ddb_counters_mps).
+-define(COUNTERS_REPAIRS, ddb_counters_repairs).
 
 
 -record(state, {dict, prefix}).
@@ -45,18 +46,25 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 
-inc() ->
-    inc(1).
+%% Increment a counter, that is stored in an ETS table so that a cumulative
+%% value can be reported for the time interval.
+inc_mps(N) ->
+    inc(N, ?COUNTERS_MPS).
 
-inc(N) ->
+inc_repairs() ->
+    inc_repairs(1).
+
+inc_repairs(N) ->
+    inc(N, ?COUNTERS_REPAIRS).
+
+inc(N, TabName) when N > 0 ->
     try
-        ets:update_counter(?COUNTERS_MPS, self(), N)
+        ets:update_counter(TabName, self(), N)
     catch
         error:badarg ->
-            ets:insert(?COUNTERS_MPS, {self(), N})
+            ets:insert(TabName, {self(), N})
     end,
     ok.
-
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -78,6 +86,8 @@ init([]) ->
     %% reporting.
     process_flag(priority, high),
     ets:new(?COUNTERS_MPS,
+            [named_table, set, public, {write_concurrency, true}]),
+    ets:new(?COUNTERS_REPAIRS,
             [named_table, set, public, {write_concurrency, true}]),
     {ok, N} = application:get_env(dalmatiner_db, n),
     {ok, W} = application:get_env(dalmatiner_db, w),
@@ -135,11 +145,12 @@ handle_info(tick, State = #state{prefix = Prefix, dict = Dict}) ->
     Time = timestamp(),
     Spec = folsom_metrics:get_metrics_info(),
 
-    MPS = ets:tab2list(?COUNTERS_MPS),
-    ets:delete_all_objects(?COUNTERS_MPS),
-    P = lists:sum([Cnt || {_, Cnt} <- MPS]),
+    MPS = sum_ets(?COUNTERS_MPS),
+    Dict2 = add_to_dict([Prefix, <<"mps">>], Time, MPS, Dict1),
 
-    Dict2 = add_to_dict([Prefix, <<"mps">>], Time, P, Dict1),
+    Repairs = sum_ets(?COUNTERS_REPAIRS),
+    folsom_metrics:notify({read_repairs, Repairs}),
+
     Dict3 = do_metrics(Prefix, Time, Spec, Dict2),
     Dict4 = bkt_dict:flush(Dict3),
 
@@ -332,3 +343,8 @@ build_histogram([{n, V} | H], Prefix, Time, Acc) ->
 
 build_histogram([_ | H], Prefix, Time, Acc) ->
     build_histogram(H, Prefix, Time, Acc).
+
+sum_ets(TabName) ->
+    Xs = ets:tab2list(TabName),
+    ets:delete_all_objects(TabName),
+    lists:sum([Cnt || {_, Cnt} <- Xs]).

--- a/apps/dalmatiner_db/src/dalmatiner_metrics.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_metrics.erl
@@ -16,7 +16,7 @@
 %% API
 -export([start_link/0, inc_mps/1, inc_repairs/0, inc_repairs/1]).
 
--ignore_xref([start_link/0, inc/0]).
+-ignore_xref([start_link/0, inc/0, inc_repairs/1]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,

--- a/apps/dalmatiner_db/src/dalmatiner_metrics.erl
+++ b/apps/dalmatiner_db/src/dalmatiner_metrics.erl
@@ -14,7 +14,7 @@
 
 
 %% API
--export([start_link/0, inc/1, inc/0]).
+-export([start_link/0, inc/2, inc/0]).
 
 -ignore_xref([start_link/0, inc/0]).
 
@@ -26,7 +26,7 @@
 -define(INTERVAL, 1000).
 -define(BUCKET, <<"dalmatinerdb">>).
 -define(COUNTERS_MPS, ddb_counters_mps).
-
+-define(COUNTERS_IOQ, ddb_counters_ioq).
 
 -record(state, {dict, prefix}).
 
@@ -44,16 +44,23 @@
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
-
 inc() ->
-    inc(1).
+    inc(1, mps).
 
-inc(N) ->
+inc(N, Kind) ->
+    case Kind of
+        mps ->
+            store_ets(N, ?COUNTERS_MPS);
+        ioq ->
+            store_ets(N, ?COUNTERS_IOQ)
+    end.
+
+store_ets(N, TabName) ->
     try
-        ets:update_counter(?COUNTERS_MPS, self(), N)
+        ets:update_counter(TabName, self(), N)
     catch
         error:badarg ->
-            ets:insert(?COUNTERS_MPS, {self(), N})
+            ets:insert(TabName, {self(), N})
     end,
     ok.
 
@@ -78,6 +85,8 @@ init([]) ->
     %% reporting.
     process_flag(priority, high),
     ets:new(?COUNTERS_MPS,
+            [named_table, set, public, {write_concurrency, true}]),
+    ets:new(?COUNTERS_IOQ,
             [named_table, set, public, {write_concurrency, true}]),
     {ok, N} = application:get_env(dalmatiner_db, n),
     {ok, W} = application:get_env(dalmatiner_db, w),
@@ -139,12 +148,17 @@ handle_info(tick, State = #state{prefix = Prefix, dict = Dict}) ->
     ets:delete_all_objects(?COUNTERS_MPS),
     P = lists:sum([Cnt || {_, Cnt} <- MPS]),
 
+    IOQ = ets:tab2list(?COUNTERS_IOQ),
+    ets:delete_all_objects(?COUNTERS_IOQ),
+    P2 = lists:sum([Cnt || {_, Cnt} <- IOQ]),
+
     Dict2 = add_to_dict([Prefix, <<"mps">>], Time, P, Dict1),
-    Dict3 = do_metrics(Prefix, Time, Spec, Dict2),
-    Dict4 = bkt_dict:flush(Dict3),
+    Dict3 = add_to_dict([Prefix, <<"ioq">>], Time, P2, Dict2),
+    Dict4 = do_metrics(Prefix, Time, Spec, Dict3),
+    Dict5 = bkt_dict:flush(Dict4),
 
     erlang:send_after(?INTERVAL, self(), tick),
-    {noreply, State#state{dict = Dict4}};
+    {noreply, State#state{dict = Dict5}};
 
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -194,7 +208,6 @@ do_metrics(Prefix, Time, [{N, [{type, spiral}]} | Spec], Acc) ->
     Acc1 = add_metric(Prefix, [K, <<"count">>], Time, Count, Acc),
     Acc2 = add_metric(Prefix, [K, <<"one">>], Time, One, Acc1),
     do_metrics(Prefix, Time, Spec, Acc2);
-
 
 do_metrics(Prefix, Time, [{N, [{type, counter}]} | Spec], Acc) ->
     Count = folsom_metrics:get_metric_value(N),

--- a/apps/metric_vnode/src/metric_io.erl
+++ b/apps/metric_vnode/src/metric_io.erl
@@ -50,10 +50,13 @@ write(Pid, Bucket, Metric, Time, Value) ->
     write(Pid, Bucket, Metric, Time, Value, ?MAX_Q_LEN).
 
 write(Pid, Bucket, Metric, Time, Value, MaxLen) ->
-    case erlang:process_info(Pid, message_queue_len) of
-        {message_queue_len, N} when N > MaxLen ->
+    {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
+    folsom_metrics:notify({io_queue_length, Len}),
+
+    if
+        Len > MaxLen ->
             swrite(Pid, Bucket, Metric, Time, Value);
-        _ ->
+        true ->
             gen_server:cast(Pid, {write, Bucket, Metric, Time, Value})
     end.
 

--- a/apps/metric_vnode/src/metric_io.erl
+++ b/apps/metric_vnode/src/metric_io.erl
@@ -50,10 +50,13 @@ write(Pid, Bucket, Metric, Time, Value) ->
     write(Pid, Bucket, Metric, Time, Value, ?MAX_Q_LEN).
 
 write(Pid, Bucket, Metric, Time, Value, MaxLen) ->
-    case erlang:process_info(Pid, message_queue_len) of
-        {message_queue_len, N} when N > MaxLen ->
+    {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
+    dalmatiner_metrics:inc(Len, ioq),
+
+    if
+        Len > MaxLen ->
             swrite(Pid, Bucket, Metric, Time, Value);
-        _ ->
+        true ->
             gen_server:cast(Pid, {write, Bucket, Metric, Time, Value})
     end.
 

--- a/apps/metric_vnode/src/metric_io.erl
+++ b/apps/metric_vnode/src/metric_io.erl
@@ -50,13 +50,10 @@ write(Pid, Bucket, Metric, Time, Value) ->
     write(Pid, Bucket, Metric, Time, Value, ?MAX_Q_LEN).
 
 write(Pid, Bucket, Metric, Time, Value, MaxLen) ->
-    {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
-    dalmatiner_metrics:inc(Len, ioq),
-
-    if
-        Len > MaxLen ->
+    case erlang:process_info(Pid, message_queue_len) of
+        {message_queue_len, N} when N > MaxLen ->
             swrite(Pid, Bucket, Metric, Time, Value);
-        true ->
+        _ ->
             gen_server:cast(Pid, {write, Bucket, Metric, Time, Value})
     end.
 

--- a/apps/metric_vnode/src/metric_io.erl
+++ b/apps/metric_vnode/src/metric_io.erl
@@ -52,9 +52,8 @@ write(Pid, Bucket, Metric, Time, Value) ->
 write(Pid, Bucket, Metric, Time, Value, MaxLen) ->
     {message_queue_len, Len} = erlang:process_info(Pid, message_queue_len),
     folsom_metrics:notify({io_queue_length, Len}),
-
-    if
-        Len > MaxLen ->
+    case Len of
+        N when N > MaxLen ->
             swrite(Pid, Bucket, Metric, Time, Value);
         true ->
             gen_server:cast(Pid, {write, Bucket, Metric, Time, Value})

--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -472,7 +472,7 @@ reply(Reply, {_, ReqID, _} = Sender, #state{node=N, partition=P}) ->
     riak_core_vnode:reply(Sender, {ok, ReqID, {P, N}, Reply}).
 
 %% The timestamp is primarily used by the vacuum to remove data in accordance
-%% with the bucket lifetime. The timestamp is only updated once per 
+%% with the bucket lifetime. The timestamp is only updated once per
 %% vacuum cycle, and may not accurately reflect the current system time.
 %% Although more performant than the monotonic `now()', there are nevertheless
 %% performance penalties for calling this too frequently. Also, updating the

--- a/apps/metric_vnode/src/metric_vnode.erl
+++ b/apps/metric_vnode/src/metric_vnode.erl
@@ -192,6 +192,7 @@ repair_update_cache(Bucket, Metric, Time, Count, Value,
 %% Repair request are always full values not including non set values!
 handle_command({repair, Bucket, Metric, Time, Value}, _Sender, State)
   when is_binary(Bucket), is_binary(Metric), is_integer(Time) ->
+    dalmatiner_metrics:inc_repairs(),
     Count = mmath_bin:length(Value),
     case valid_ts(Time + Count, Bucket, State) of
         {true, State1} ->


### PR DESCRIPTION
This PR introduces the following additional metrics for DDb:
- a histogram that tracks the message queue length of the `metric_io` process.  This process serialises reads and writes to a metric store, for a single instance of a VNode.
- a meter that tracks the number of read repair operations.  This includes a counter, as well as 1-, 5-, and 15-minute moving averages. 

Both metrics have been tested locally on a 4 node cluster.

<!---
@huboard:{"custom_state":"archived"}
-->
