### PR TITLE
Return partition and nodename as tuple when replying to the read FSM

### DIFF
--- a/apps/metric_vnode/eqc/metric_vnode_eqc.erl
+++ b/apps/metric_vnode/eqc/metric_vnode_eqc.erl
@@ -74,19 +74,18 @@ overlap(Tr, Start, Vs) ->
 
 get(S, T, C) ->
     ReqID = T,
+    ReplyNode = nonode@nohost,
     Command = {get, ReqID, ?B, ?M, {T, C}},
     case ?V:handle_command(Command, {raw, ReqID, self()}, S) of
         {noreply, _S1} ->
             receive
-                {ReqID, {ok, ReqID, _, D}} ->
+                {ReqID, {ok, ReqID, {_Partition, ReplyNode}, D}} ->
                     D
             after
                 1000 ->
                     timeout
             end;
-        {reply, {ok, _, _, Reply}, _S1} ->
-            Reply;
-        {reply, {ok, Reply}, _S1} ->
+        {reply, {ok, _, {_Partition, ReplyNode}, Reply}, _S1} ->
             Reply
     end.
 


### PR DESCRIPTION
When a get request is serviced from cache, the metric vnode responds with information about it's partition, but not the nodename.  This information is used by the read FSM to issue commands to repair any data that is in conflict.  
This PR fixes/enforces the 2-tuple convention that is required by riak-core, when issuing a command.  This is only enforced on a get, since the rest of the commands seem to use a well formed preference list (a list of 2 tuples).  The repair scenario seems to be the only case where a destination tuple singleton is used to address a command to a specific VNode directly, by dalmatiner.

<!---
@huboard:{"custom_state":"archived","order":11,"milestone_order":11}
-->
